### PR TITLE
Fix prettier config

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,16 +1,10 @@
 "use strict";
 
 module.exports = {
+  plugins: ["prettier-plugin-ember-template-tag"],
   overrides: [
     {
-      files: "*.{js,ts}",
-      options: {
-        singleQuote: true,
-      },
-    },
-    {
-      files: "*.{gjs,gts}",
-      plugins: ["prettier-plugin-ember-template-tag"],
+      files: "*.{js,ts,gjs,gts}",
       options: {
         singleQuote: true,
       },

--- a/app/components/excite.gts
+++ b/app/components/excite.gts
@@ -1,20 +1,23 @@
 import { modifier } from 'ember-modifier';
 
-const intensify = modifier(element => {
-  let animation = element.animate([
-    { transform: "translateX(1px)" },
-    { transform: "translateY(1px)" },
-    { transform: "translateX(-1px)" },
-  ], {
-    duration: 100,
-    iterations: Infinity,
-  });
+const intensify = modifier((element) => {
+  let animation = element.animate(
+    [
+      { transform: 'translateX(1px)' },
+      { transform: 'translateY(1px)' },
+      { transform: 'translateX(-1px)' },
+    ],
+    {
+      duration: 100,
+      iterations: Infinity,
+    },
+  );
 
   return () => animation.cancel();
 });
 
 export const Excite = <template>
-  <div {{intensify}} style="position: fixed; bottom: 1rem; left: 1rem;">
+  <div {{intensify}} style='position: fixed; bottom: 1rem; left: 1rem;'>
     🥳
   </div>
 </template>;

--- a/app/components/welcome.gts
+++ b/app/components/welcome.gts
@@ -19,61 +19,76 @@ export default Welcome;
 
 const Header = <template>
   <header>
-    <img src='/images/logo.png' width='50' height='50' alt='an unofficial polaris logo. a gold compass rose sits in a space setting with kaleidoscopic colors showing through the compass.' />
+    <img
+      src='/images/logo.png'
+      width='50'
+      height='50'
+      alt='an unofficial polaris logo. a gold compass rose sits in a space setting with kaleidoscopic colors showing through the compass.'
+    />
     <h1>Welcome to Polaris</h1>
   </header>
 </template>;
 
 const Links = <template>
-    <ul>
-      <li>
-        <a href="https://tutorial.glimdown.com">Tutorial</a>
-          <span>Get familiar with Ember's new file format, programming patterns, paradigms, and new way of thinking about reactivity</span>
-      </li>
-      <li>
-      <a href="https://github.com/NullVoxPopuli/ember-resources/tree/main/docs/docs">Docs: Resources</a>
-        <span>Learn about the new reactivity primitive</span>
-        </li>
-      <li>
-        <a href="https://github.com/jmurphyau/ember-truth-helpers">ember-truth-helpers</a>
-        <span>Additional template helpers (coming soon to Ember.js)</span>
-      </li>
-      <li>
-        <a href="https://typescript.org">TypeScript</a>
-        <span>TypeScript always enabled, always optional</span>
-      </li>
-      <li>
-        <a href="https://vitejs.dev/">Vite</a><span>* Coming soon by default</span>
-      </li>
-    </ul>
+  <ul>
+    <li>
+      <a href='https://tutorial.glimdown.com'>Tutorial</a>
+      <span>Get familiar with Ember's new file format, programming patterns,
+        paradigms, and new way of thinking about reactivity</span>
+    </li>
+    <li>
+      <a
+        href='https://github.com/NullVoxPopuli/ember-resources/tree/main/docs/docs'
+      >Docs: Resources</a>
+      <span>Learn about the new reactivity primitive</span>
+    </li>
+    <li>
+      <a
+        href='https://github.com/jmurphyau/ember-truth-helpers'
+      >ember-truth-helpers</a>
+      <span>Additional template helpers (coming soon to Ember.js)</span>
+    </li>
+    <li>
+      <a href='https://typescript.org'>TypeScript</a>
+      <span>TypeScript always enabled, always optional</span>
+    </li>
+    <li>
+      <a href='https://vitejs.dev/'>Vite</a><span>* Coming soon by default</span>
+    </li>
+  </ul>
 
-    <ul>
-      <li>
-        <a href="https://stackblitz.com/github/nullVoxPopuli/polaris-starter/tree/main"> StackBlitz </a>
-        <span> Try it on StackBlitz</span>
-      </li>
+  <ul>
+    <li>
+      <a
+        href='https://stackblitz.com/github/nullVoxPopuli/polaris-starter/tree/main'
+      > StackBlitz </a>
+      <span> Try it on StackBlitz</span>
+    </li>
 
-      <li>
-        <a href="https://stackblitz.com/github/nullVoxPopuli/polaris-starter/tree/monorepo"> StackBlitz (mono-repo) </a>
-        <span> Try the mono-repo version on StackBlitz</span>
-      </li>
+    <li>
+      <a
+        href='https://stackblitz.com/github/nullVoxPopuli/polaris-starter/tree/monorepo'
+      > StackBlitz (mono-repo) </a>
+      <span> Try the mono-repo version on StackBlitz</span>
+    </li>
 
-      <li>
-        <a href="https://discord.gg/emberjs">Discord</a>
-        <span>Join the community Discord</span>
-      </li>
-    </ul>
+    <li>
+      <a href='https://discord.gg/emberjs'>Discord</a>
+      <span>Join the community Discord</span>
+    </li>
+  </ul>
 </template>;
 
 const Footer = <template>
   <div class='footer'>
-    <a href="https://github.com/NullVoxPopuli/polaris-starter/tree/main" class='github'>
-      <img alt="" src="/images/github-logo.png" />
+    <a
+      href='https://github.com/NullVoxPopuli/polaris-starter/tree/main'
+      class='github'
+    >
+      <img alt='' src='/images/github-logo.png' />
       Fork Starter Project on GitHub
     </a>
   </div>
 
   <Excite />
 </template>;
-
-


### PR DESCRIPTION
Any malformed .gjs/.gts file was not fixed by prettier. Can be reproduced in Stackblitz as well. 

There is another issue, that running the `lint:prettier:fix` script does not touch any .gjs/.gts files, but that seems to be an upstream issue: https://github.com/gitKrystan/prettier-plugin-ember-template-tag/issues/113